### PR TITLE
PHP Library - Fix for undefined symbol error ZVAL_ADDREF

### DIFF
--- a/php/jlog.c
+++ b/php/jlog.c
@@ -334,7 +334,7 @@ PHP_METHOD(Jlog_Writer, open)
     php_error(E_WARNING, "jlog_ctx_open_writer failed");
     RETURN_NULL();
   }
-  ZVAL_ADDREF(_this_zval);
+  Z_ADDREF_P(_this_zval);
   return_value = _this_zval;
 }
 /* }}} open */
@@ -414,7 +414,7 @@ PHP_METHOD(Jlog_Reader, open)
   if(jlog_ctx_open_reader(jo->ctx, subscriber) != 0) {
     RETURN_NULL();
   }
-  ZVAL_ADDREF(_this_zval);
+  Z_ADDREF_P(_this_zval);
   return_value = _this_zval;
 }
 /* }}} open */
@@ -525,7 +525,7 @@ PHP_METHOD(Jlog_Reader, checkpoint)
     jo->start = epoch;
     jo->end = epoch;
   }
-  ZVAL_ADDREF(_this_zval);
+  Z_ADDREF_P(_this_zval);
   return_value = _this_zval;
 }
 /* }}} checkpoint */


### PR DESCRIPTION
An undefined symbol error [1] is encountered when attempting to use the PHP jlog library with PHP 5.3. It appears ZVAL_ADDREF was replaced with Z_ADDREF_P per this PHP-Internals discussion [2]. Replacing the ZVAL_ADDREF calls with Z_ADDREF_P addresses this issue for me on PHP 5.3, allowing me to read the jlog.

[1]  jlog.so: undefined symbol: ZVAL_ADDREF.

[2] http://grokbase.com/t/php/php-internals/0794vpam1g/patch-for-macros-for-tracking-refcount-and-is-ref
