### PR TITLE
Make Repair Function Respect Header Magic Value

### DIFF
--- a/jlog.c
+++ b/jlog.c
@@ -170,8 +170,8 @@ int jlog_repair_datafile(jlog_ctx *ctx, u_int32_t log)
     continue;
   error:
     for (next = this + sizeof(hdr); next + sizeof(hdr) <= mmap_end; next++) {
-      if (!next[0] && !next[1] && !next[2] && !next[3]) {
-        memcpy(&hdr, next, sizeof(hdr));
+      memcpy(&hdr, next, sizeof(hdr));
+      if (hdr.reserved == ctx->meta->hdr_magic) {
         afternext = next + sizeof(hdr) + hdr.mlen;
         if (afternext <= (char *)ctx->mmap_base) continue;
         if (afternext == mmap_end) break;


### PR DESCRIPTION
Old repair function was checking for zero values rather than checking
the header magic value. We need to actually check the header magic
value; otherwise, the repair will fail for any magic value that isn't
0x00000000.