### PR TITLE
memory leak in jlog_file_close() under FreeBSD

### DIFF
--- a/jlog_io.c
+++ b/jlog_io.c
@@ -129,6 +129,7 @@ int jlog_file_close(jlog_file *f)
     assert(jlog_hash_delete(&jlog_files, (void *)&f->id, sizeof(jlog_file_id),
                             NULL, NULL));
     while (close(f->fd) == -1 && errno == EINTR) ;
+    pthread_mutex_destroy(&(f->lock));
     free(f);
   }
   pthread_mutex_unlock(&jlog_files_lock);  


### PR DESCRIPTION
Under linux this doesn't cause a leak because pthread_mutex_t is not malloc'd during init. On FreeBSD it is so destroy must be called.