### PR TITLE
make install: depend on `all`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -108,7 +108,7 @@ java/com_omniti_labs_jlog.lo:	java/com_omniti_labs_jlog.c
 java/libjlog.jnilib:	java/com_omniti_labs_jlog.lo $(SOOBJS)
 	$(SHLD) -o $@ java/com_omniti_labs_jlog.lo $(SOOBJS) $(LDFLAGS) $(LIBS)
 
-install:
+install: all
 	$(srcdir)/mkinstalldirs $(DESTDIR)$(bindir)
 	$(srcdir)/mkinstalldirs $(DESTDIR)$(libdir)
 	$(srcdir)/mkinstalldirs $(DESTDIR)$(includedir)


### PR DESCRIPTION
So we can just run `make install` without running `make` first.