### PR TITLE
workaround ZFS bug with lack of modtime alter on mmap'd file changes

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -47,6 +47,7 @@ int main(void){sem_t s;return (0 != sem_init(&s,0,0));}
 AC_CHECK_LIB(lz4, LZ4_compress_default, , )
 AC_FUNC_STRFTIME
 AC_CHECK_FUNC(pwritev, [AC_DEFINE(HAVE_PWRITEV)], )
+AC_CHECK_FUNC(futimesat, [AC_DEFINE(HAVE_FUTIMESAT)], )
 
 # Checks for header files.
 AC_CHECK_HEADERS(sys/file.h sys/types.h sys/uio.h dirent.h sys/param.h libgen.h \

--- a/jlog.c
+++ b/jlog.c
@@ -623,6 +623,10 @@ static int __jlog_save_metastore(jlog_ctx *ctx, int ilocked)
     if(ctx->meta->safety == JLOG_SAFE) flags |= MS_SYNC;
     rv = msync((void *)(ctx->meta), sizeof(*ctx->meta), flags);
     FASSERT(rv >= 0, "jlog_save_metastore");
+    if (ctx->touch_mmaps) {
+      rv = jlog_file_touch(ctx->metastore);
+      FASSERT(rv >= 0, "jlog_save_metastore, touch");      
+    }
     if (!ilocked) jlog_file_unlock(ctx->metastore);
     if ( rv < 0 )
       ctx->last_error = JLOG_ERR_FILE_WRITE;
@@ -1322,6 +1326,12 @@ int jlog_ctx_alter_safety(jlog_ctx *ctx, jlog_safety safety) {
   return -1;
 }
 
+int jlog_ctx_touch_mmapped_files(jlog_ctx *ctx, int touch)
+{
+  ctx->touch_mmaps = touch;
+  return 0;
+}
+
 int jlog_ctx_set_multi_process(jlog_ctx *ctx, uint8_t mp) {
   ctx->multi_process = mp;
   return 0;
@@ -1405,6 +1415,11 @@ _jlog_ctx_flush_pre_commit_buffer_no_lock(jlog_ctx *ctx)
   ctx->pre_commit_pos = ctx->pre_commit_buffer;
   /* ensure we save this in the mmapped data */
   *ctx->pre_commit_pointer = 0;
+
+  if (ctx->touch_mmaps) {
+    int rv = jlog_file_touch(ctx->pre_commit);
+    FASSERT(rv >= 0, "jlog_flush_pre_commit_buffer_no_lock, touch");      
+  }
 
   if(ctx->meta->unit_limit <= current_offset) {
     jlog_file_unlock(ctx->data);
@@ -1751,6 +1766,11 @@ int jlog_ctx_write_message(jlog_ctx *ctx, jlog_message *mess, struct timeval *wh
     ctx->pre_commit_pos = ctx->pre_commit_buffer;
     /* ensure we save this in the mmapped data */
     *ctx->pre_commit_pointer = 0;
+
+    if (ctx->touch_mmaps) {
+      int rv = jlog_file_touch(ctx->pre_commit);
+      FASSERT(rv >= 0, "jlog_ctx_write_message, pre_commit, touch");      
+    }
   }
  
   if (total_size <= ctx->pre_commit_buffer_len) {

--- a/jlog.h
+++ b/jlog.h
@@ -159,6 +159,7 @@ JLOG_API(int)       jlog_ctx_alter_mode(jlog_ctx *ctx, int mode);
 JLOG_API(int)       jlog_ctx_alter_journal_size(jlog_ctx *ctx, size_t size);
 JLOG_API(int)       jlog_ctx_repair(jlog_ctx *ctx, int aggressive);
 JLOG_API(int)       jlog_ctx_alter_safety(jlog_ctx *ctx, jlog_safety safety);
+JLOG_API(int)       jlog_ctx_touch_mmapped_files(jlog_ctx *ctx, int touch);
 
 /**
  * Control whether this jlog process should use multi-process safe file locks when performing 

--- a/jlog_config.h.in
+++ b/jlog_config.h.in
@@ -60,6 +60,7 @@
 #undef HAVE_U_INT
 #undef HAVE_U_INT64_T
 #undef HAVE_U_INTXX_T
+#undef HAVE_FUTIMESAT
 #define IFS_CH '/'
 
 #ifdef HAVE_STRING_H
@@ -82,6 +83,9 @@
 #endif
 #if HAVE_LIBGEN_H
 #include <libgen.h>
+#endif
+#if HAVE_FUTIMESAT
+#include <sys/time.h>
 #endif
 
 

--- a/jlog_io.h
+++ b/jlog_io.h
@@ -105,6 +105,13 @@ int jlog_file_pwritev(jlog_file *f, const struct iovec *vec, int iov_count, off_
 int jlog_file_sync(jlog_file *f);
 
 /**
+ * call futimes to change modification time of the file
+ * return 1 on success, 0 on failure
+ * @internal
+ */
+int jlog_file_touch(jlog_file *f);
+
+/**
  * maps the entirety of a jlog_file into memory for reading and writing
  * @param[in] f the jlog_file on which you are operating
  * @param[out] base is set to the base of the mapped region

--- a/jlog_private.h
+++ b/jlog_private.h
@@ -69,6 +69,7 @@ struct _jlog_ctx {
   pthread_mutex_t write_lock;
   int       meta_is_mapped;
   int       pre_commit_is_mapped;
+  int       touch_mmaps;
   uint8_t   multi_process;
   uint8_t   pre_commit_buffer_size_specified;
   void      *pre_commit_buffer;

--- a/jtest.c
+++ b/jtest.c
@@ -125,6 +125,7 @@ void jcreate(const char *path, int compressed) {
   ctx = jlog_new(path);
   jlog_ctx_set_use_compression(ctx, compressed);
   jlog_ctx_alter_journal_size(ctx, 1024000);
+  jlog_ctx_touch_mmapped_files(ctx, 1);
   if(jlog_ctx_init(ctx) != 0) {
     fprintf(stderr, "jlog_ctx_init failed: %d %s\n", jlog_ctx_err(ctx), jlog_ctx_err_string(ctx));
   } else {
@@ -135,6 +136,7 @@ void jcreate(const char *path, int compressed) {
 
 void jresize_pre_commit(const char *path, size_t pre_commit_size) {
   ctx = jlog_new(path);
+  jlog_ctx_touch_mmapped_files(ctx, 1);
   jlog_ctx_set_pre_commit_buffer_size(ctx, pre_commit_size);
   jlog_ctx_open_writer(ctx);
 
@@ -229,7 +231,7 @@ void jopenw(char *foo, int count, const char *path) {
   s = f = my_gethrtime();
 
   ctx = jlog_new(path);
-
+  jlog_ctx_touch_mmapped_files(ctx, 1);
   jlog_ctx_set_multi_process(ctx, 0);
   if(jlog_ctx_open_writer(ctx) != 0) {
     fprintf(stderr, "jlog_ctx_open_writer failed: %d %s\n", jlog_ctx_err(ctx), jlog_ctx_err_string(ctx));
@@ -262,6 +264,8 @@ void jopenr(char *s, int expect, const char *path) {
   jlog_message message;
 
   ctx = jlog_new(path);
+  jlog_ctx_touch_mmapped_files(ctx, 1);
+
   if(jlog_ctx_open_reader(ctx, s) != 0) {
     fprintf(stderr, "jlog_ctx_open_reader failed: %d %s\n", jlog_ctx_err(ctx), jlog_ctx_err_string(ctx));
     exit(-1);


### PR DESCRIPTION
ZFS does not touch atime or mtime on mmapped files on illumos and BSD:

https://github.com/openzfs/openzfs/pull/221
https://www.illumos.org/issues/5379

Work around this by providing an internal `jlog_file_touch` which relies on the non-posix `futimesat` but appears to actually exist on linux, bsd and illumos anyway; and a new jlog option to turn on this bad touching so ZFSers can workaround this issue.

