### PR TITLE
Prefer _GNU_SOURCE to _BSD_SOURCE and _SVID_SOURCE.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -243,7 +243,7 @@ case $host in
     fi
     ;;
   *linux*)
-    CFLAGS="$CFLAGS -D_BSD_SOURCE -D_SVID_SOURCE"
+    CFLAGS="$CFLAGS -D_GNU_SOURCE"
     RLDFLAG="-Wl,--rpath="
     case `uname -m` in
       *x86_64*)


### PR DESCRIPTION
This fixes the build on Fedora 25, where the combination of `_BSD_SOURCE` and `_SVID_SOURCE` produces a warning. It's not obvious what features are required, but `_GNU_SOURCE` is widely used and works AFAICT.

```
[jpeach@sk1 jlog]$ make
gcc -I/usr/java/include -I/usr/java/include/solaris -g -O2 -Wall -Wno-int-to-pointer-cast -Werror -D_BSD_SOURCE -D_SVID_SOURCE -D_REENTRANT -fPIC -shared -c jlog.c -o jlog.lo
In file included from /usr/include/stdio.h:27:0,
                 from jlog.c:70:
/usr/include/features.h:148:3: error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^~~~~~~
cc1: all warnings being treated as errors
Makefile:57: recipe for target 'jlog.lo' failed
make: *** [jlog.lo] Error 1
```