### PR TITLE
Add jlog_ctx_bulk_read_messages Function

### DIFF
--- a/jlog.h
+++ b/jlog.h
@@ -238,6 +238,7 @@ JLOG_API(int)       jlog_ctx_write_message(jlog_ctx *ctx, jlog_message *msg, str
 JLOG_API(int)       jlog_ctx_read_interval(jlog_ctx *ctx,
                                            jlog_id *first_mess, jlog_id *last_mess);
 JLOG_API(int)       jlog_ctx_read_message(jlog_ctx *ctx, const jlog_id *, jlog_message *);
+JLOG_API(int)       jlog_ctx_bulk_read_messages(jlog_ctx *ctx, const jlog_id *, const int, jlog_message *);
 JLOG_API(int)       jlog_ctx_read_checkpoint(jlog_ctx *ctx, const jlog_id *checkpoint);
 JLOG_API(int)       jlog_snprint_logid(char *buff, int n, const jlog_id *checkpoint);
 


### PR DESCRIPTION
Add a new function, jlog_ctx_bulk_read_messages, which will allow
passing in a count and will attempt to read in <count> messages.

This will fail if not all messages are read properly.

This assumes that enough memory has been passed in to accomodate all the
messages; behavior is undefined if insufficient memory has been
allocated.