### PR TITLE
resync_index: fix restart dependency on ctx->data.

### DIFF
--- a/jlog.c
+++ b/jlog.c
@@ -1042,13 +1042,6 @@ ___jlog_resync_index(jlog_ctx *ctx, u_int32_t log, jlog_id *last, int *closed)
   ctx->last_error = JLOG_ERR_SUCCESS;
   if(closed) *closed = 0;
 
-  __jlog_open_reader(ctx, log);
-  if (!ctx->data) {
-    ctx->last_error = JLOG_ERR_FILE_OPEN;
-    ctx->last_errno = errno;
-    return -1;
-  }
-
 #define RESTART do { \
   if (second_try == 0) { \
     jlog_file_truncate(ctx->index, index_off); \
@@ -1061,6 +1054,12 @@ ___jlog_resync_index(jlog_ctx *ctx, u_int32_t log, jlog_id *last, int *closed)
 } while (0)
 
 restart:
+  __jlog_open_reader(ctx, log);
+  if (!ctx->data) {
+    ctx->last_error = JLOG_ERR_FILE_OPEN;
+    ctx->last_errno = errno;
+    return -1;
+  }
   __jlog_open_indexer(ctx, log);
   if (!ctx->index) {
     ctx->last_error = JLOG_ERR_IDX_OPEN;


### PR DESCRIPTION
Ran into a crash at jlog.c:1077, where, after a `goto restart`, `ctx->data` was closed and not reopened, due to only calling `__jlog_open_indexer`.  This changes the `__jlog_open_reader` call so both are reopened if this happens.  I'm not 100% sure if this is the correct fix, but the two functions appear to do pretty much the same thing regardless of the order they're called in, and they're called in this specific order elsewhere.