### PR TITLE
Skip parent dir in ownership check

### DIFF
--- a/jlogctl.c
+++ b/jlogctl.c
@@ -153,6 +153,10 @@ static int ownership_check(const char *path) {
   }
   int rv = 0;
   while((de = readdir(dir)) != NULL) {
+    /* No need to test our parent directory */
+    if(!strcmp(de->d_name, "..")) {
+      continue;
+    }
     char fullfile[MAXPATHLEN];
     snprintf(fullfile, sizeof(fullfile), "%s/%s", path, de->d_name);
     if(stat(fullfile, &st) != 0) {


### PR DESCRIPTION
Can lead to a confusing error message, such as this from a Circonus Enterprise Broker:

```
.. owner/group [0/0] doesn't match jlog [43191/43191]

A permissions mismatch can cause these to fail later
*IF* the jlog ownership is correct you can run (as root):

  chown -R 43191:43191 /opt/noit/prod/log/noitd.feed
```

The ownership of the parent directory (`/opt/noit/prod/log` in this case) is not particularly relevant to the operation of the jlog.