### PR TITLE
Fix Potential Short Write On jlog_file_pwritev

### DIFF
--- a/jlog.c
+++ b/jlog.c
@@ -1847,11 +1847,11 @@ int jlog_ctx_write_message(jlog_ctx *ctx, jlog_message *mess, struct timeval *wh
     }
   } else {
     /* incoming message won't fit in pre_commit buffer, it was flushed above so write to file directly. */
-    if (!jlog_file_pwritev(ctx->data, v, 2, current_offset)) {
+    if (!jlog_file_pwritev_verify_return_value(ctx->data, v, 2, current_offset, total_size)) {
       FASSERT(ctx, 0, "jlog_file_pwritev failed in jlog_ctx_write_message");
       SYS_FAIL(JLOG_ERR_FILE_WRITE);
     }
-    current_offset += v[0].iov_len + v[1].iov_len;
+    current_offset += total_size;;
   }
 
   if (IS_COMPRESS_MAGIC(ctx) && v[1].iov_base != compress_space) {

--- a/jlog_io.h
+++ b/jlog_io.h
@@ -91,7 +91,15 @@ int jlog_file_pread(jlog_file *f, void *buf, size_t nbyte, off_t offset);
 int jlog_file_pwrite(jlog_file *f, const void *buf, size_t nbyte, off_t offset);
 
 /**
- * pwritevs to a jlog_file, retries EINTR
+ * pwritevs to a jlog_file, retries EINTR. takes the expected bytes written as an argument.
+ * @return 1 if the write was fully satisfied, 0 otherwise
+ * @internal
+ */
+int jlog_file_pwritev_verify_return_value(jlog_file *f, const struct iovec *vecs, int iov_count, off_t offset,
+                                          size_t expected_length);
+
+/**
+ * pwritevs to a jlog_file, retries EINTR. calculates the expected bytes written internally.
  * @return 1 if the write was fully satisfied, 0 otherwise
  * @internal
  */


### PR DESCRIPTION
jlog_file_pwritev was not checking to verify that the correct number of bytes were written. Change this so that if we get short writes, we will retry until we actually write the whole amount.

Added a new function, jlog_file_pwritev_verify_return_value that takes the expected bytes as an input; this is because otherwise, the existing jlog_file_writev will have to loop through all of the vectors and calculate the value when it's possible that this value will be known in advance. This prevents this extra calculation when the correct value is already known without breaking compatibility with the existing API.