### PR TITLE
Fix Compile Error/Break Statement

### DIFF
--- a/jlog.c
+++ b/jlog.c
@@ -984,6 +984,8 @@ static int __jlog_setup_reader(jlog_ctx *ctx, u_int32_t log, u_int8_t force_mmap
         }
       }
       ctx->reader_is_initialized = 1;
+      return 0;
+      break;
     case JLOG_READ_METHOD_PREAD:
       if (force_mmap) {
         int rv = __jlog_mmap_reader(ctx, log);

--- a/jlog.c
+++ b/jlog.c
@@ -977,9 +977,11 @@ static int __jlog_setup_reader(jlog_ctx *ctx, u_int32_t log, u_int8_t force_mmap
 
   switch (read_method) {
     case JLOG_READ_METHOD_MMAP:
-      int rv = __jlog_mmap_reader(ctx, log);
-      if (rv > 0) {
-        return -1;
+      {
+        int rv = __jlog_mmap_reader(ctx, log);
+        if (rv > 0) {
+          return -1;
+        }
       }
       ctx->reader_is_initialized = 1;
     case JLOG_READ_METHOD_PREAD:

--- a/jlog.c
+++ b/jlog.c
@@ -985,7 +985,6 @@ static int __jlog_setup_reader(jlog_ctx *ctx, u_int32_t log, u_int8_t force_mmap
       }
       ctx->reader_is_initialized = 1;
       return 0;
-      break;
     case JLOG_READ_METHOD_PREAD:
       if (force_mmap) {
         int rv = __jlog_mmap_reader(ctx, log);
@@ -1002,7 +1001,6 @@ static int __jlog_setup_reader(jlog_ctx *ctx, u_int32_t log, u_int8_t force_mmap
       }
       ctx->reader_is_initialized = 1;
       return 0;
-      break;
     default:
      SYS_FAIL(JLOG_ERR_NOT_SUPPORTED);
      break;

--- a/jlog.c
+++ b/jlog.c
@@ -979,7 +979,7 @@ static int __jlog_setup_reader(jlog_ctx *ctx, u_int32_t log, u_int8_t force_mmap
     case JLOG_READ_METHOD_MMAP:
       {
         int rv = __jlog_mmap_reader(ctx, log);
-        if (rv > 0) {
+        if (rv != 0) {
           return -1;
         }
       }
@@ -989,7 +989,7 @@ static int __jlog_setup_reader(jlog_ctx *ctx, u_int32_t log, u_int8_t force_mmap
     case JLOG_READ_METHOD_PREAD:
       if (force_mmap) {
         int rv = __jlog_mmap_reader(ctx, log);
-        if (rv > 0) {
+        if (rv != 0) {
           return -1;
         }
       }


### PR DESCRIPTION
Fix a compiler error that occurred on some versions of gcc and add a break statement to prevent doing unnecessary file stat calls.